### PR TITLE
Refactor/remove binarrayindex optimize binarray creation

### DIFF
--- a/services/core.ts
+++ b/services/core.ts
@@ -369,7 +369,7 @@ export class LiquidityBookServices extends LiquidityBookAbstract {
 
     if (binArrayIndexLower !== binArrayIndexUpper) {
     await this.getBinArray({
-      binArrayIndex: binArrayIndexUpper + 1,
+      binArrayIndex: binArrayIndexUpper,
       pair,
       payer,
     });

--- a/services/core.ts
+++ b/services/core.ts
@@ -334,6 +334,16 @@ export class LiquidityBookServices extends LiquidityBookAbstract {
       transaction,
     } = params;
 
+    const pairInfo = await this.getPairAccount(pair);
+
+    const activeBinId = pairInfo.activeId;
+
+    const lowerBinId = activeBinId + relativeBinIdLeft;
+    const upperBinId = activeBinId + relativeBinIdRight;
+
+    const binArrayIndexLower = Math.floor(lowerBinId / BIN_ARRAY_SIZE);
+    const binArrayIndexUpper = Math.floor(upperBinId / BIN_ARRAY_SIZE);
+
     const position = PublicKey.findProgramAddressSync(
       [
         Buffer.from(utils.bytes.utf8.encode("position")),
@@ -342,6 +352,7 @@ export class LiquidityBookServices extends LiquidityBookAbstract {
       this.lbProgram.programId
     )[0];
 
+    
     const positionVault = spl.getAssociatedTokenAddressSync(
       positionMint,
       payer,
@@ -355,11 +366,15 @@ export class LiquidityBookServices extends LiquidityBookAbstract {
       payer,
     });
 
+     // access/create two binarray only if lowerBinId and upperBinId are not in the same binArray
+
+    if (binArrayIndexLower !== binArrayIndexUpper) {
     await this.getBinArray({
       binArrayIndex: binArrayIndex + 1,
       pair,
       payer,
     });
+  }
 
     const initializePositionTx = await this.lbProgram.methods
       .createPosition(new BN(relativeBinIdLeft), new BN(relativeBinIdRight))

--- a/services/core.ts
+++ b/services/core.ts
@@ -329,7 +329,6 @@ export class LiquidityBookServices extends LiquidityBookAbstract {
       relativeBinIdLeft,
       relativeBinIdRight,
       pair,
-      binArrayIndex,
       positionMint,
       transaction,
     } = params;
@@ -361,7 +360,7 @@ export class LiquidityBookServices extends LiquidityBookAbstract {
     );
 
     await this.getBinArray({
-      binArrayIndex,
+      binArrayIndex: binArrayIndexLower,
       pair,
       payer,
     });
@@ -370,7 +369,7 @@ export class LiquidityBookServices extends LiquidityBookAbstract {
 
     if (binArrayIndexLower !== binArrayIndexUpper) {
     await this.getBinArray({
-      binArrayIndex: binArrayIndex + 1,
+      binArrayIndex: binArrayIndexUpper + 1,
       pair,
       payer,
     });

--- a/types/services.ts
+++ b/types/services.ts
@@ -117,7 +117,6 @@ export interface CreatePositionParams {
   relativeBinIdLeft: number;
   relativeBinIdRight: number;
   pair: PublicKey;
-  binArrayIndex: number;
   positionMint: PublicKey;
   transaction: Transaction;
 }


### PR DESCRIPTION
This pull request improves the efficiency and safety of position createPosition  in the SDK by:

- Preventing unnecessary access and creation of bin arrays. Now, only the required bin array(s) for a given position’s price range are accessed/created, reducing transaction fees and on-chain account bloat.
- Removing the `binArrayIndex` parameter from the `createPosition` function. The SDK now calculates the necessary bin array indices internally, eliminating a major source of potential user error.

 Why these changes are necessary

- Unconditional creation of multiple bin arrays increased costs for users, especially when the position range fit within a single bin array.
- Allowing external code to specify `binArrayIndex` risked critical errors if an incorrect index was provided. Internalizing this logic ensures only valid, needed bin arrays are used.
- These changes make the SDK safer, more efficient, and easier for developers to use correctly.

Closes #15

